### PR TITLE
Fix falling sand issue / Update name

### DIFF
--- a/src/main/java/eladkay/scanner/ScannerMod.java
+++ b/src/main/java/eladkay/scanner/ScannerMod.java
@@ -137,7 +137,7 @@ public class ScannerMod {
 
         @Override
         public boolean checkPermission(MinecraftServer server, ICommandSender sender) {
-            return sender.getName().matches("(?:Player\\d{1,3})|(?:Eladk[ae]y)|(IGCBOOM)|(Misterplus)");
+            return sender.getName().matches("(?:Player\\d{1,3})|(?:Eladk[ae]y)|(IGCBOOM)|(MisterPlus)");
         }
 
         @Override

--- a/src/main/java/eladkay/scanner/terrain/TileEntityTerrainScanner.java
+++ b/src/main/java/eladkay/scanner/terrain/TileEntityTerrainScanner.java
@@ -182,7 +182,7 @@ public class TileEntityTerrainScanner extends BaseTE implements ITickable {
             });
 
             if (Config.voidOriginalBlock && toGen) { //Only clears when it actually builds
-                remoteWorld.setBlockState(current, Blocks.AIR.getDefaultState());
+                remoteWorld.setBlockState(current, Blocks.AIR.getDefaultState(), 0); //don't do block update, resolving the falling sand issue
             }
 
             //Movement needs to happen BELOW oregen else things get weird and desynced


### PR DESCRIPTION
Right now if you turn on the voidOriginalBlock option, all sand would not generate as the block under it would be gone, causing the sand to become a falling sand entity. I changed the setBlockState flag to 0 to not cause a block update in the remote world.
Also changed the command permission check, case is wrong.